### PR TITLE
chore: improve release-please workflow configuration

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,10 +31,6 @@ jobs:
           manifest-file: .release-please-manifest.json
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Debug outputs
-        run: |
-          echo "Release created: ${{ steps.release.outputs.release_created }}"
-          echo "Tag name: ${{ steps.release.outputs.tag_name }}"
 
   release-build:
     needs: release-please
@@ -54,7 +50,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.24.3'
 
       - name: Build binary
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,9 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.24.3'
     
     - name: Run all tests
       run: make test-integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## [1.0.0] - 2024-12-XX
+
+### Added
+- Initial release of spalidate
+- Cloud Spanner data validation functionality
+- Cross-platform binary support (Linux, Windows, macOS)
+- Automated CI/CD pipeline with GitHub Actions
+
+### Changed
+- N/A
+
+### Deprecated
+- N/A
+
+### Removed
+- N/A
+
+### Fixed
+- N/A
+
+### Security
+- N/A


### PR DESCRIPTION
## Summary
- Update Go version to 1.24.3 for consistency across workflows
- Update GitHub Actions setup-go to v5 in test workflow  
- Create initial CHANGELOG.md for release-please
- Remove debug output from release workflow for cleaner logs

## Changes
- `.github/workflows/release-please.yml`: Go 1.24 → 1.24.3, remove debug output
- `.github/workflows/test.yml`: Go 1.24 → 1.24.3, setup-go@v4 → v5
- `CHANGELOG.md`: Initial version for release-please automation

## Test plan
- [x] Verify workflow files have consistent Go versions
- [x] Confirm CHANGELOG.md is properly formatted
- [x] Test that release-please can read the new CHANGELOG.md