### PR TITLE
feat: add manual tag creation workflow

### DIFF
--- a/.github/workflows/create-tag.yaml
+++ b/.github/workflows/create-tag.yaml
@@ -1,0 +1,34 @@
+name: Create Tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag (e.g., v0.1.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  create_tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin https://${{ secrets.PAT_FOR_TAG_PUSH }}@github.com/${{ github.repository }}
+      - name: Create and push tag
+        run: |
+          git tag ${{ github.event.inputs.version }}
+          git push origin main
+          git push origin ${{ github.event.inputs.version }}


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for manual tag creation via workflow_dispatch
- Provides alternative to automated release-please process for special cases
- Requires PAT (Personal Access Token) secret configuration

## Details

This PR adds a new GitHub Actions workflow that allows manual tag creation through the GitHub UI. The workflow:

1. **Accepts version input** - User provides the tag version (e.g., v0.1.0)
2. **Creates and pushes tag** - Uses git commands to create and push the tag
3. **Uses PAT for authentication** - Requires `PAT_FOR_TAG_PUSH` secret

### Why is this needed?

While the project uses release-please for automated releases, there may be cases where manual tag creation is necessary:
- Hotfix releases outside the normal release cycle
- Re-tagging if automated process fails
- Special releases that don't follow standard versioning

### Required Setup

⚠️ **Before merging**: The repository needs a secret named `PAT_FOR_TAG_PUSH` with a Personal Access Token that has:
- `repo` scope (for pushing tags)
- `workflow` scope (if the tag triggers other workflows)

### Security Considerations

The workflow uses a PAT instead of the default GITHUB_TOKEN because:
- GITHUB_TOKEN cannot trigger other workflows (by design)
- If tag creation should trigger release workflows, a PAT is required

### Test Plan

1. After merge, navigate to Actions → Manual Tag Creation
2. Click "Run workflow"
3. Enter a version (e.g., v0.0.1-test)
4. Verify tag is created and pushed successfully
5. Clean up test tag if needed

## Related
- Existing release automation: `.github/workflows/release-please.yml`
- Release configuration: `release-please-config.json`