### PR TITLE
feat: add comprehensive timestamp validation tests

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -388,6 +388,149 @@ func TestIntegrationSpalidate(t *testing.T) {
 			t.Errorf("Expected table not found message, got: %s", outputStr)
 		}
 	})
+
+	// Test timestamp validation with different formats
+	t.Run("TimestampValidation", func(t *testing.T) {
+		// Load test fixtures
+		if err := prepareTestDatabase(); err != nil {
+			t.Fatalf("Failed to prepare test database: %v", err)
+		}
+		// Create a validation file with different timestamp formats
+		timestampContent := `tables:
+  Users:
+    count: 3
+    order_by: "UserID"
+    rows:
+      - UserID: "user-001"
+        Name: "Alice Johnson"
+        Email: "alice@example.com"
+        Status: 1
+        CreatedAt: "2024-01-01T00:00:00Z"  # RFC3339
+      - UserID: "user-002"
+        Name: "Bob Smith"
+        Email: "bob@example.com"
+        Status: 2
+        CreatedAt: "2024-01-01 00:00:00"  # Alternative format
+      - UserID: "user-003"
+        Name: "Charlie Brown"
+        Email: "charlie@example.com"
+        Status: 1
+        CreatedAt: "2024-01-01T00:00:00"  # Without timezone
+`
+
+		timestampFile := "testdata/validation_timestamp.yaml"
+		if err := os.WriteFile(timestampFile, []byte(timestampContent), 0644); err != nil {
+			t.Fatalf("Failed to create timestamp validation file: %v", err)
+		}
+		defer os.Remove(timestampFile)
+
+		cmd := exec.Command("./spalidate-test",
+			"--project", testProject,
+			"--instance", testInstance,
+			"--database", testDatabase,
+			"--port", "9010",
+			"--verbose",
+			timestampFile,
+		)
+
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("spalidate command failed: %v\nOutput: %s", err, string(output))
+		}
+
+		outputStr := string(output)
+		if !contains(outputStr, "✅ All validations passed!") {
+			t.Errorf("Expected successful validation message, got: %s", outputStr)
+		}
+		
+		// Check that timestamp fields were validated
+		if !contains(outputStr, "CreatedAt: value matches") {
+			t.Errorf("Expected timestamp validation message, got: %s", outputStr)
+		}
+	})
+
+	// Test advanced timestamp validation with truncation and multiple formats
+	t.Run("AdvancedTimestampValidation", func(t *testing.T) {
+		// Load test fixtures
+		if err := prepareTestDatabase(); err != nil {
+			t.Fatalf("Failed to prepare test database: %v", err)
+		}
+		
+		// Create test fixtures with different timestamp precision
+		advancedTimestampContent := `tables:
+  Products:
+    count: 3
+    order_by: "ProductID"
+    rows:
+      - ProductID: "prod-001"
+        Name: "Laptop Computer"
+        Price: 150000
+        IsActive: true
+        CategoryID: "cat-electronics"
+        CreatedAt: "2024-01-01T00:00:00Z"  # Exact match
+      - ProductID: "prod-002"
+        Name: "Wireless Mouse"
+        Price: 3000
+        IsActive: true
+        CategoryID: "cat-electronics"
+        CreatedAt: "2024-01-01T00:00:00.000Z"  # With milliseconds
+      - ProductID: "prod-003"
+        Name: "Coffee Mug"
+        Price: 1200
+        IsActive: false
+        CategoryID: "cat-kitchen"
+        CreatedAt: "2024-01-01T00:00:00+00:00"  # Different timezone format
+  Orders:
+    count: 3
+    order_by: "OrderID"
+    rows:
+      - OrderID: "order-001"
+        UserID: "user-001"
+        ProductID: "prod-001"
+        Quantity: 1
+        OrderDate: "2024-01-01T00:00:00Z"
+      - OrderID: "order-002"
+        UserID: "user-002"
+        ProductID: "prod-002"
+        Quantity: 2
+        OrderDate: "2024-01-01 00:00:00"  # Space separator format
+      - OrderID: "order-003"
+        UserID: "user-001"
+        ProductID: "prod-003"
+        Quantity: 1
+        OrderDate: "2024-01-01T00:00:00.000000Z"  # With microseconds
+`
+
+		advancedTimestampFile := "testdata/validation_advanced_timestamp.yaml"
+		if err := os.WriteFile(advancedTimestampFile, []byte(advancedTimestampContent), 0644); err != nil {
+			t.Fatalf("Failed to create advanced timestamp validation file: %v", err)
+		}
+		defer os.Remove(advancedTimestampFile)
+
+		cmd := exec.Command("./spalidate-test",
+			"--project", testProject,
+			"--instance", testInstance,
+			"--database", testDatabase,
+			"--port", "9010",
+			"--verbose",
+			advancedTimestampFile,
+		)
+
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("spalidate command failed: %v\nOutput: %s", err, string(output))
+		}
+
+		outputStr := string(output)
+		if !contains(outputStr, "✅ All validations passed!") {
+			t.Errorf("Expected successful validation message, got: %s", outputStr)
+		}
+		
+		// Check that timestamp fields were validated
+		if !contains(outputStr, "CreatedAt: value matches") || !contains(outputStr, "OrderDate: value matches") {
+			t.Errorf("Expected timestamp validation messages, got: %s", outputStr)
+		}
+	})
 }
 
 func waitForSpannerEmulator() error {

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -645,6 +645,78 @@ func TestComparisonOptions(t *testing.T) {
 	}
 }
 
+func TestCompareTimestampWithMultipleFormats(t *testing.T) {
+	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		options  ComparisonOptions
+		expected interface{}
+		actual   interface{}
+		want     bool
+	}{
+		{
+			name:     "RFC3339 with Z timezone",
+			options:  DefaultComparisonOptions(),
+			expected: "2024-01-01T00:00:00Z",
+			actual:   baseTime,
+			want:     true,
+		},
+		{
+			name:     "alternative format without T separator",
+			options:  DefaultComparisonOptions(),
+			expected: "2024-01-01 00:00:00",
+			actual:   baseTime,
+			want:     true,
+		},
+		{
+			name:     "without timezone suffix",
+			options:  DefaultComparisonOptions(),
+			expected: "2024-01-01T00:00:00",
+			actual:   baseTime,
+			want:     true,
+		},
+		{
+			name:     "date only format",
+			options:  DefaultComparisonOptions(),
+			expected: "2024-01-01",
+			actual:   baseTime,
+			want:     true,
+		},
+		{
+			name:     "timestamp with nanoseconds",
+			options:  DefaultComparisonOptions(),
+			expected: "2024-01-01T00:00:00.123456789Z",
+			actual:   time.Date(2024, 1, 1, 0, 0, 0, 123456789, time.UTC),
+			want:     true,
+		},
+		{
+			name:     "timestamp truncation to seconds",
+			options:  ComparisonOptions{TimestampTruncateTo: time.Second},
+			expected: "2024-01-01T00:00:00Z",
+			actual:   time.Date(2024, 1, 1, 0, 0, 0, 999999999, time.UTC),
+			want:     true,
+		},
+		{
+			name:     "timestamp truncation to minutes",
+			options:  ComparisonOptions{TimestampTruncateTo: time.Minute},
+			expected: "2024-01-01T00:00:00Z",
+			actual:   time.Date(2024, 1, 1, 0, 0, 59, 0, time.UTC),
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := NewWithOptions(nil, tt.options)
+			result := v.compareTimestamp(tt.expected, tt.actual)
+			if result != tt.want {
+				t.Errorf("compareTimestamp() = %v, want %v", result, tt.want)
+			}
+		})
+	}
+}
+
 func mustParseBigRat(s string) *big.Rat {
 	r, ok := new(big.Rat).SetString(s)
 	if !ok {

--- a/testdata/validation.yaml
+++ b/testdata/validation.yaml
@@ -8,14 +8,17 @@ tables:
         Name: "Alice Johnson"
         Email: "alice@example.com"
         Status: 1
+        CreatedAt: "2024-01-01T00:00:00Z"
       - UserID: "user-002"
         Name: "Bob Smith"
         Email: "bob@example.com"
         Status: 2
+        CreatedAt: "2024-01-01T00:00:00Z"
       - UserID: "user-003"
         Name: "Charlie Brown"
         Email: "charlie@example.com"
         Status: 1
+        CreatedAt: "2024-01-01T00:00:00Z"
   
   # Products table validation with order_by
   Products:
@@ -27,16 +30,19 @@ tables:
         Price: 150000
         IsActive: true
         CategoryID: "cat-electronics"
+        CreatedAt: "2024-01-01T00:00:00Z"
       - ProductID: "prod-002"
         Name: "Wireless Mouse"
         Price: 3000
         IsActive: true
         CategoryID: "cat-electronics"
+        CreatedAt: "2024-01-01T00:00:00Z"
       - ProductID: "prod-003"
         Name: "Coffee Mug"
         Price: 1200
         IsActive: false
         CategoryID: "cat-kitchen"
+        CreatedAt: "2024-01-01T00:00:00Z"
   
   # Orders table validation (interleaved table)
   Orders:
@@ -47,14 +53,17 @@ tables:
         UserID: "user-001"
         ProductID: "prod-001"
         Quantity: 1
+        OrderDate: "2024-01-01T00:00:00Z"
       - OrderID: "order-002"
         UserID: "user-002"
         ProductID: "prod-002"
         Quantity: 2
+        OrderDate: "2024-01-01T00:00:00Z"
       - OrderID: "order-003"
         UserID: "user-001"
         ProductID: "prod-003"
         Quantity: 1
+        OrderDate: "2024-01-01T00:00:00Z"
   
   # JSON validation
   json:


### PR DESCRIPTION
## Summary
- Added comprehensive timestamp validation tests to verify date/time handling capabilities
- Enhanced integration tests to cover multiple timestamp formats
- Updated validation configuration to include timestamp fields for all tables

## Changes
1. **Updated testdata/validation.yaml**
   - Added `CreatedAt` field to Users, Products tables
   - Added `OrderDate` field to Orders table
   - All timestamp fields are properly validated

2. **Enhanced integration_test.go**
   - Added new `AdvancedTimestampValidation` test case
   - Tests multiple timestamp formats including:
     - RFC3339: `2024-01-01T00:00:00Z`
     - Space separator: `2024-01-01 00:00:00`
     - With milliseconds: `2024-01-01T00:00:00.000Z`
     - With microseconds: `2024-01-01T00:00:00.000000Z`
     - Different timezone format: `2024-01-01T00:00:00+00:00`

3. **Fixed unit tests in validator_test.go**
   - Added timestamp truncation test to verify time comparison logic

## Test Results
✅ All unit tests pass:
```
ok  	github.com/nu0ma/spalidate/internal/config	(cached)
ok  	github.com/nu0ma/spalidate/internal/validator	0.299s
```

✅ All integration tests pass:
```
=== RUN   TestIntegrationSpalidate
=== RUN   TestIntegrationSpalidate/SuccessfulValidation
=== RUN   TestIntegrationSpalidate/FailureValidation
=== RUN   TestIntegrationSpalidate/FailureValidationWrongColumns
=== RUN   TestIntegrationSpalidate/PrimaryKeyBasedComparison
=== RUN   TestIntegrationSpalidate/NumericToleranceComparison
=== RUN   TestIntegrationSpalidate/CompositePrimaryKey
=== RUN   TestIntegrationSpalidate/NonExistentTable
=== RUN   TestIntegrationSpalidate/TimestampValidation
=== RUN   TestIntegrationSpalidate/AdvancedTimestampValidation
--- PASS: TestIntegrationSpalidate (1.79s)
    --- PASS: TestIntegrationSpalidate/SuccessfulValidation (0.48s)
    --- PASS: TestIntegrationSpalidate/FailureValidation (0.06s)
    --- PASS: TestIntegrationSpalidate/FailureValidationWrongColumns (0.05s)
    --- PASS: TestIntegrationSpalidate/PrimaryKeyBasedComparison (0.05s)
    --- PASS: TestIntegrationSpalidate/NumericToleranceComparison (0.05s)
    --- PASS: TestIntegrationSpalidate/CompositePrimaryKey (0.05s)
    --- PASS: TestIntegrationSpalidate/NonExistentTable (0.03s)
    --- PASS: TestIntegrationSpalidate/TimestampValidation (0.05s)
    --- PASS: TestIntegrationSpalidate/AdvancedTimestampValidation (0.07s)
PASS
ok  	command-line-arguments	2.191s
```

## Notes
- Fixed test case that used unsupported slash date separator format (`2024/01/01`) 
- Project already had timestamp validation support, this PR adds comprehensive test coverage
- No changes to core validation logic were needed

Closes #17