### PR TITLE
fix: resolve undefined symbol errors in integration tests

### DIFF
--- a/test/integration/helpers.go
+++ b/test/integration/helpers.go
@@ -8,6 +8,14 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"github.com/nu0ma/spalidate/internal/testutil"
+)
+
+const (
+	testProject  = "test-project"
+	testInstance = "test-instance"
+	testDatabase = "test-database"
 )
 
 // TestConfig holds configuration for running spalidate tests
@@ -73,6 +81,11 @@ func RunSpalidate(t *testing.T, config *TestConfig) ([]byte, error) {
 	// Execute command
 	cmd := exec.Command(config.BinaryPath, args...)
 	return cmd.CombinedOutput()
+}
+
+// prepareTestDatabase prepares the test database with fixtures
+func prepareTestDatabase() error {
+	return testutil.LoadFixtures()
 }
 
 // BuildSpalidate builds the spalidate binary for testing

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -23,9 +23,6 @@ import (
 
 const (
 	spannerEmulatorHost = "localhost:9010"
-	testProject         = "test-project"
-	testInstance        = "test-instance"
-	testDatabase        = "test-database"
 )
 
 func TestMain(m *testing.M) {
@@ -50,10 +47,6 @@ func TestMain(m *testing.M) {
 	// Run tests
 	code := m.Run()
 	os.Exit(code)
-}
-
-func prepareTestDatabase() error {
-	return testutil.LoadFixtures()
 }
 
 func waitForSpannerEmulator() error {


### PR DESCRIPTION
## Summary
- Fixed undefined symbol errors in integration tests that were preventing compilation
- Resolved duplicate declarations causing build failures
- All 9 integration tests now pass successfully

## Changes Made
- **Move shared constants** from `main_test.go` to `helpers.go`:
  - `testProject = "test-project"`
  - `testInstance = "test-instance"`  
  - `testDatabase = "test-database"`
- **Move `prepareTestDatabase()` function** from `main_test.go` to `helpers.go`
- **Add missing import** for `testutil` package in `helpers.go`
- **Remove duplicate declarations** from `main_test.go`

## Issues Fixed
The following compiler errors are now resolved:
- `undefined: testProject`
- `undefined: testInstance` 
- `undefined: testDatabase`
- `undefined: prepareTestDatabase`

## Test Results
✅ All 9 integration tests pass:
- TestColumnValidationFailure
- TestCountValidationFailure
- TestNonExistentTable
- TestNumericToleranceComparison
- TestPrimaryKeyBasedComparison
- TestCompositePrimaryKey
- TestSuccessfulValidation
- TestTimestampValidation
- TestAdvancedTimestampValidation

✅ Unit tests continue to pass

## Test Plan
- [x] Verify integration tests compile without errors
- [x] Run all integration tests to ensure they pass
- [x] Run unit tests to ensure no regressions
- [x] Verify proper code organization with shared constants in helpers.go