### PR TITLE
chore: update Go version to 1.24.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nu0ma/spalidate
 
-go 1.24.3
+go 1.24.5
 
 require (
 	cloud.google.com/go v0.121.3


### PR DESCRIPTION
## Summary
- Updated Go version from 1.24.3 to 1.24.5 in go.mod
- Ran go mod tidy to ensure dependencies are up to date

## Test plan
- [x] Updated go.mod file
- [x] Ran go mod tidy successfully
- [ ] CI tests will verify the new Go version works correctly