### PR TITLE
Add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A command-line tool for validating data in Google Cloud Spanner emulator against YAML configuration files.
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/nu0ma/spalidate)
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## Summary
• Add DeepWiki badge to README for enhanced documentation access

## Test plan
- [x] Verify badge displays correctly in README
- [x] Confirm badge links to correct DeepWiki page