### PR TITLE
chore: pin GitHub Actions to specific commits

### DIFF
--- a/.github/workflows/create-tag.yaml
+++ b/.github/workflows/create-tag.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
     
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@19bb51245e9c80abacb2e91cc42b33fa478b8639 # v4.2.1
       with:
         go-version: '1.24'
 
     - name: Golangci-lint
-      uses: golangci/golangci-lint-action@v8.0.0
+      uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
     
     - name: Run all tests
       run: make test


### PR DESCRIPTION
## Summary
- Pin GitHub Actions to specific commit SHAs for improved security
- Prevent potential supply chain attacks through action version hijacking

## Changes
- `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955`
- `actions/setup-go@v4` → `actions/setup-go@19bb51245e9c80abacb2e91cc42b33fa478b8639`
- `golangci/golangci-lint-action@v8.0.0` → `golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9`

## Test plan
- [ ] GitHub Actions workflows continue to run successfully
- [ ] All CI checks pass